### PR TITLE
CI: Update to Python 3.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,8 +55,12 @@ jobs:
         # https://github.com/pypa/setuptools/blob/main/CHANGES.rst#v6400
         pip install "setuptools>=64" --upgrade
 
+        # FIXME: Workaround for installing pendulum 2.x on Python 3.12.
+        # https://github.com/sdispater/pendulum/issues/454#issuecomment-654096754
+        pip install poetry wheel
+
         # Install package in editable mode.
-        pip install --use-pep517 --prefer-binary --editable=.[develop,docs,test]
+        pip install --use-pep517 --prefer-binary --no-build-isolation --editable=.[develop,docs,test]
 
     - name: Run linter and software tests
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.8", "3.12"]
 
     env:
       OS: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -17,7 +17,15 @@ and further stops on the trip, and computes travel plan drafts using the [HAFAS]
 
 Install the most recent version of reX9.
 ```shell
-pip install --upgrade 'git+https://github.com/panodata/rex9'
+pip install \
+  --use-pep517 --prefer-binary --no-build-isolation \
+  --upgrade 'git+https://github.com/panodata/rex9'
+```
+
+On Python 3.12, make sure to also install the `poetry` and `wheel` packages
+before running the main installation command above.
+```shell
+pip install poetry wheel
 ```
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ name = "rex9"
 version = "0.0.0"
 description = "Public transport routing based on time, locations, interests, and heuristics"
 readme = "README.md"
-requires-python = ">=3.8,<3.12"
+requires-python = ">=3.8"
 license = {text = "AGPL"}
 keywords = [
   "open data",
@@ -41,6 +41,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Topic :: Communications",
   "Topic :: Education",
   "Topic :: Home Automation",


### PR DESCRIPTION
This reverts commit 5d93ee6a5218a17af7f63bc810755c2c84182c95. Contrary to what has been stated ...

> #### CI: Downgrade to Python 3.11 
> Because aika pulls in arbitrary-dateparser, and this one pulls in
pendulum==2.0.5, the build fails on Python 3.12, because that old
version would need a compiler to build on modern Python, because there
are no corresponding binary wheel packages available.

... the Aika package, which pulls in pendulum==2.0.5, works well on Python 3.12:

https://github.com/panodata/aika
